### PR TITLE
Align whoami/config show output with #113 spec

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -182,9 +182,15 @@ func runConfigShow(cmd *cobra.Command, args []string) error {
 	// Get database path
 	dbPath, _ := db.GetDefaultDBPath()
 
+	// Get project root (data already available via FindProjectRoot)
+	projectRoot := "(unknown)"
+	if root, err := db.FindProjectRoot(); err == nil {
+		projectRoot = root
+	}
+
 	// Get mode
-	mode := "default"
-	if modeConfig, err := db.GetConfig(models.ConfigMode); err == nil {
+	mode := models.ModeDefault
+	if modeConfig, err := db.GetConfig(models.ConfigMode); err == nil && modeConfig != "" {
 		mode = modeConfig
 	}
 
@@ -210,8 +216,10 @@ func runConfigShow(cmd *cobra.Command, args []string) error {
 	tokenSet := tokenErr == nil
 
 	if IsJSONOutput() {
+		// Keep existing flat keys for backward compatibility; add project_root.
 		OutputJSON(map[string]interface{}{
 			"database":       dbPath,
+			"project_root":   projectRoot,
 			"mode":           mode,
 			"schema_version": schema,
 			"initialized_at": initializedAt,
@@ -224,13 +232,11 @@ func runConfigShow(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Println("Configuration")
-	fmt.Println("=============")
-	fmt.Printf("Database:     %s\n", dbPath)
-	fmt.Printf("Mode:         %s\n", mode)
-	fmt.Printf("Schema:       %s\n", schema)
+	fmt.Println("Configuration:")
+	fmt.Printf("  Mode:         %s\n", mode)
+	fmt.Printf("  Schema:       %s\n", schema)
 	if initializedAt != "" {
-		fmt.Printf("Initialized:  %s\n", initializedAt)
+		fmt.Printf("  Initialized:  %s\n", initializedAt)
 	}
 
 	fmt.Println("\nGitHub:")
@@ -243,8 +249,12 @@ func runConfigShow(cmd *cobra.Command, args []string) error {
 			fmt.Println("  Token:        (not configured)")
 		}
 	} else {
-		fmt.Println("  (not configured)")
+		fmt.Println("  (not configured — run 'gur config github')")
 	}
+
+	fmt.Println("\nPaths:")
+	fmt.Printf("  Database:     %s\n", dbPath)
+	fmt.Printf("  Project Root: %s\n", projectRoot)
 
 	return nil
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Giancarlos/guardrails/internal/db"
@@ -73,5 +75,59 @@ func TestConfigMachineNameConstants(t *testing.T) {
 	// They should be different
 	if models.ConfigMachineName == models.ConfigMachineShare {
 		t.Error("ConfigMachineName and ConfigMachineShare should be different")
+	}
+}
+
+func TestConfigShowHasThreeSections(t *testing.T) {
+	tmpDir := withTempDB(t)
+	withVerboseOutput(t)
+
+	out := captureStdout(t, func() {
+		if err := runConfigShow(nil, nil); err != nil {
+			t.Fatalf("runConfigShow: %v", err)
+		}
+	})
+
+	for _, want := range []string{"Configuration:", "GitHub:", "Paths:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing section %q:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "Project Root: "+tmpDir) {
+		t.Errorf("output missing 'Project Root: %s':\n%s", tmpDir, out)
+	}
+	// Database should now appear under Paths, not above the GitHub block.
+	pathsIdx := strings.Index(out, "Paths:")
+	dbIdx := strings.Index(out, "Database:")
+	if pathsIdx == -1 || dbIdx == -1 || dbIdx < pathsIdx {
+		t.Errorf("expected 'Database:' to appear after 'Paths:' header:\n%s", out)
+	}
+}
+
+func TestConfigShowJSONIncludesProjectRoot(t *testing.T) {
+	tmpDir := withTempDB(t)
+	prevVerbose, prevJSON := verboseOutput, jsonOutput
+	verboseOutput = false
+	jsonOutput = true
+	t.Cleanup(func() { verboseOutput = prevVerbose; jsonOutput = prevJSON })
+
+	out := captureStdout(t, func() {
+		if err := runConfigShow(nil, nil); err != nil {
+			t.Fatalf("runConfigShow: %v", err)
+		}
+	})
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	if got := parsed["project_root"]; got != tmpDir {
+		t.Errorf("project_root = %v, want %q", got, tmpDir)
+	}
+	// Existing flat keys should remain for backward compatibility.
+	for _, k := range []string{"database", "mode", "schema_version", "github"} {
+		if _, ok := parsed[k]; !ok {
+			t.Errorf("expected flat JSON key %q to still be present", k)
+		}
 	}
 }

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -48,9 +47,16 @@ func runWhoami(cmd *cobra.Command, args []string) error {
 	// Get database path
 	dbPath, _ := db.GetDefaultDBPath()
 
+	// Get mode (defaults to "default" if unset, mirroring runConfigShow)
+	mode := models.ModeDefault
+	if modeConfig, err := db.GetConfig(models.ConfigMode); err == nil && modeConfig != "" {
+		mode = modeConfig
+	}
+
 	if IsJSONOutput() {
 		result := map[string]interface{}{
 			"machine_hash": hostnameHash,
+			"mode":         mode,
 			"database":     dbPath,
 		}
 		if repo != "" {
@@ -63,25 +69,15 @@ func runWhoami(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if IsCompactOutput() {
-		parts := []string{"machine:" + hostnameHash}
-		if username != "" {
-			parts = append(parts, "github:@"+username+"/"+repo)
-		} else if repo != "" {
-			parts = append(parts, "github:"+repo)
-		}
-		fmt.Println(strings.Join(parts, " "))
-		return nil
-	}
-
-	fmt.Printf("Machine:  %s\n", hostnameHash)
 	if username != "" {
 		fmt.Printf("GitHub:   @%s (%s)\n", username, repo)
 	} else if repo != "" {
 		fmt.Printf("GitHub:   %s\n", repo)
 	} else {
-		fmt.Println("GitHub:   (not configured)")
+		fmt.Println("GitHub:   (not configured — run 'gur config github')")
 	}
+	fmt.Printf("Machine:  %s\n", hostnameHash)
+	fmt.Printf("Mode:     %s\n", mode)
 	fmt.Printf("Database: %s\n", dbPath)
 
 	return nil

--- a/cmd/whoami_test.go
+++ b/cmd/whoami_test.go
@@ -1,11 +1,139 @@
 package cmd
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/Giancarlos/guardrails/internal/db"
+	"github.com/Giancarlos/guardrails/internal/models"
 )
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what was written.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+// withTempDB sets up a fresh sqlite db in a temp dir and tears it down. Returns the project root.
+func withTempDB(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	guardrailsDir := filepath.Join(tmpDir, ".guardrails")
+	if err := os.MkdirAll(guardrailsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	dbPath := filepath.Join(guardrailsDir, "db.sqlite")
+	t.Setenv("GUR_DB_PATH", dbPath)
+	if _, err := db.InitDB(dbPath); err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	t.Cleanup(func() { db.CloseDB() })
+
+	// Run inside the temp project so FindProjectRoot resolves.
+	origCwd, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origCwd) })
+	return tmpDir
+}
+
+// withVerboseOutput forces non-compact, non-JSON output for the duration of the test.
+func withVerboseOutput(t *testing.T) {
+	t.Helper()
+	prevVerbose, prevJSON := verboseOutput, jsonOutput
+	verboseOutput = true
+	jsonOutput = false
+	t.Cleanup(func() {
+		verboseOutput = prevVerbose
+		jsonOutput = prevJSON
+	})
+}
+
+func TestWhoamiIncludesMode(t *testing.T) {
+	withTempDB(t)
+	withVerboseOutput(t)
+
+	if err := db.SetConfig(models.ConfigMode, models.ModeStealth); err != nil {
+		t.Fatalf("set mode: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := runWhoami(nil, nil); err != nil {
+			t.Fatalf("runWhoami: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Mode:") {
+		t.Errorf("whoami output missing 'Mode:' line:\n%s", out)
+	}
+	if !strings.Contains(out, models.ModeStealth) {
+		t.Errorf("whoami output missing mode value %q:\n%s", models.ModeStealth, out)
+	}
+}
+
+func TestWhoamiModeDefaultsWhenUnset(t *testing.T) {
+	withTempDB(t)
+	withVerboseOutput(t)
+
+	out := captureStdout(t, func() {
+		if err := runWhoami(nil, nil); err != nil {
+			t.Fatalf("runWhoami: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Mode:     "+models.ModeDefault) {
+		t.Errorf("expected mode to default to %q:\n%s", models.ModeDefault, out)
+	}
+}
+
+func TestWhoamiJSONIncludesMode(t *testing.T) {
+	withTempDB(t)
+	prevVerbose, prevJSON := verboseOutput, jsonOutput
+	verboseOutput = false
+	jsonOutput = true
+	t.Cleanup(func() { verboseOutput = prevVerbose; jsonOutput = prevJSON })
+
+	if err := db.SetConfig(models.ConfigMode, models.ModeContributor); err != nil {
+		t.Fatalf("set mode: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := runWhoami(nil, nil); err != nil {
+			t.Fatalf("runWhoami: %v", err)
+		}
+	})
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	if got := parsed["mode"]; got != models.ModeContributor {
+		t.Errorf("json mode = %v, want %q", got, models.ModeContributor)
+	}
+}
 
 func TestHashHostname(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- `gur whoami` gains a `Mode:` line and drops the compact single-line variant — `whoami` is a debug/info command and the multi-line shape matches the example in #113. `--json` still covers machine consumers.
- `gur config show` is restructured into `Configuration:` / `GitHub:` / `Paths:` sections matching the spec, and gains a `Project Root:` line via the existing `db.FindProjectRoot()` helper.
- Both commands replace the bare `(not configured)` message with an actionable hint pointing at `gur config github`.

## Notes for reviewers
- **Hashed hostname kept on purpose.** The issue example literally says "hostname", but every other code path in the project (`cmd/sync_pull.go:404` `hashHostname`) hashes it for privacy. I didn't want to silently regress that — happy to switch to raw hostname if you'd rather match the spec verbatim.
- **JSON shape preserved.** All existing flat keys in `gur config show --json` remain (`database`, `mode`, `schema_version`, `initialized_at`, `github`); only `project_root` is added. `gur whoami --json` adds `mode`. No consumers in-tree reference these keys, so a nested `paths` object would also be safe — went with flat to minimize blast radius.
- New tests use a `captureStdout` / `withTempDB` / `withVerboseOutput` helper trio added to `cmd/whoami_test.go`. Reusable from other tests if useful.

Closes #113
